### PR TITLE
add script for replacing LDFLAGS directives with $GOPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,12 @@ In order for Go to find libvix when running your compiled binary, a govix path h
 Be aware that the previous example assumes $GOPATH only has a path set.
 
 Additionally, due to an [issue](https://code.google.com/p/go/issues/detail?id=5428) in Go, the CGO LDFLAGS
-directive has to have an absolute path in order for govix to compile.
+directive has to have an absolute path in order for govix to compile. In order to achieve this on your
+machine, there is a Bash script provided which will probably work:
+
+```
+sh replace-ldflags.sh
+````
 
 
 

--- a/replace-ldflags.sh
+++ b/replace-ldflags.sh
@@ -1,0 +1,12 @@
+# we need to run this:
+# sed -e "s/\(#cgo darwin LDFLAGS: -L\).*\(src\/github.com\/c4milo\/govix\)/\1 GOPATH\2/" -i '' *.go
+# except "GOPATH" needs to be the $GOPATH with forward-slashes escaped
+
+# TODO: perhaps allow an argument to this script, and use that instead of $GOPATH
+# TODO: somehow use /Applications/VMware Fusion.app/Contents/Public and ./libvx ?? peace doesn't understand...
+
+PATH_SEP="/"
+PATH_SEP_ESCAPED="\\/"
+GOPATH_ESCAPED="${GOPATH//$PATH_SEP/$PATH_SEP_ESCAPED}"
+
+sed -e "s/\(#cgo darwin LDFLAGS: -L\).*\(src\/github.com\/c4milo\/govix\)/\1 $GOPATH_ESCAPED\/\2/" -i '' *.go


### PR DESCRIPTION
After I run this (and replace the VM path in `examples/bar.go`) I'm able to run the `bar.go` example.

Baby steps! :baby: 
