### PR TITLE
Fixed examples, fixed compilation with go 1.8, updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # VMware VIX API for GO
+
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/hooklift/govix?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![GoDoc](https://godoc.org/github.com/hooklift/govix?status.svg)](https://godoc.org/github.com/hooklift/govix)
 [![Build Status](https://travis-ci.org/hooklift/govix.svg?branch=master)](https://travis-ci.org/hooklift/govix)
+[![Golang](https://img.shields.io/badge/Go-1.8-blue.svg)](https://golang.org)
 
 The VIX API allows you to automate virtual machine operations on most current VMware hosted products such as: vmware workstation, player, fusion and server.
 
 vSphere API, starting from 5.0, merged VIX API in the so-called GuestOperationsManager managed object. So, we encourage you to use https://github.com/vmware/govmomi for vSphere instead.
 
 ## Mailing list
+
 **Google groups:** https://groups.google.com/group/govix
 
 ## Features
+
 This API supports:
 
 * Adding, removing and listing virtual networks adapters attached to a VM
@@ -26,9 +30,26 @@ This API supports:
 
 For a more detailed information about the API, please refer to the API documentation.
 
+## Installation
+
+Clone the repo and use the makefile for running the examples.
+When compiling your application that imports govix make sure to set the required ENV vars.
+
+For this example, the libvix dependecy has been copied into the projects vendor directory:
+
+```shell
+pwd=$(pwd)
+CGO_CFLAGS="-I$pwd/vendor/libvix/include -Werror" \
+CGO_LDFLAGS="-L$pwd/vendor/libvix -lvixAllProducts -ldl -lpthread" \
+DYLD_LIBRARY_PATH="$pwd/vendor/libvix" \
+LD_LIBRARY_PATH="$pwd/vendor/libvix" \
+go install
+```
+
 ## To keep in mind when running your apps
 
-#### Dynamic library loading
+### Dynamic library loading
+
 In order for Go to find libvix when running your compiled binary, a govix path has to be added to the *LD_LIBRARY_PATH* environment variable. Example:
 
 * **OSX:** `export DYLD_LIBRARY_PATH=${GOPATH}/src/github.com/hooklift/govix/vendor/libvix`
@@ -38,12 +59,14 @@ In order for Go to find libvix when running your compiled binary, a govix path h
 Be aware that the previous example assumes $GOPATH only has one path set.
 
 ## Debugging
+
 ### Enabling debug logs
 
 `echo "vix.debugLevel = \"9\"" >> ~/Library/Preferences/VMware\ Fusion/config`
 
 
 ### Logs
+
 * **OSX:** `~/Library/Logs/VMware/*.log`
 * **Linux:** `/tmp/vmware-<username>/vix-<pid>.log`
 * **Windows:** `%TEMP%\vmware-<username>\vix-<pid>.log`
@@ -56,6 +79,7 @@ objects are managed by the Vix library to avoid conflicts between threads.
 Clients need only be responsible for protecting user-defined shared data.
 
 ## VMware VIX EULA
+
 As noted in the End User License Agreement, the VIX API allows you to build and distribute your own applications. To facilitate this, the following files are designated as redistributable for the purpose of that agreement:
 
 * VixAllProducts.lib

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For a more detailed information about the API, please refer to the API documenta
 Clone the repo and use the makefile for running the examples.
 When compiling your application that imports govix make sure to set the required ENV vars.
 
-For this example, the libvix dependecy has been copied into the projects vendor directory:
+In this example, the libvix dependecy has been copied into the projects vendor directory:
 
 ```shell
 pwd=$(pwd)

--- a/examples/bar.go
+++ b/examples/bar.go
@@ -6,7 +6,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/hooklift/govix"
+	"github.com/dreadl0ck/govix"
 )
 
 func main() {
@@ -20,7 +20,7 @@ func main() {
 
 	defer host.Disconnect()
 
-	vm, err := host.OpenVm("/Users/camilo/Documents/Virtual Machines.localized/Ubuntu 64-bit.vmwarevm/Ubuntu 64-bit.vmx", "")
+	vm, err := host.OpenVM("/Users/alien/Documents/Virtual Machines.localized/INSPECT.vmwarevm/INSPECT.vmx", "")
 	if err != nil {
 		panic(err)
 	}

--- a/examples/foo.go
+++ b/examples/foo.go
@@ -6,7 +6,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/hooklift/govix"
+	"github.com/dreadl0ck/govix"
 )
 
 func main() {
@@ -30,12 +30,12 @@ func main() {
 	fmt.Println("host.findItems returned!")
 
 	for _, url := range urls {
-		vm, _ := host.OpenVm(url, "")
+		vm, _ := host.OpenVM(url, "")
 		fmt.Println("Url: " + url)
 		vcpus, _ := vm.Vcpus()
 		memsize, _ := vm.MemorySize()
 		vmxpath, _ := vm.VmxPath()
-		teampath, _ := vm.VmTeamPath()
+		teampath, _ := vm.VMTeamPath()
 		guestos, _ := vm.GuestOS()
 		//features, _ := vm.Features()
 		fmt.Printf("vcpus: %d\n", vcpus)

--- a/helper.c
+++ b/helper.c
@@ -155,8 +155,9 @@ void find_items_callback(
     }
 
     go_callback_char(goCallback, url);
-
+    free(goCallback);
     Vix_FreeBuffer(url);
+
 }
 
 VixError get_guest_file(VixHandle jobHandle, int i, char* name, int64* size, int64* modtime, int* flags) {

--- a/helper.c
+++ b/helper.c
@@ -153,8 +153,9 @@ void find_items_callback(
         printf("Error %s\n", Vix_GetErrorText(err, NULL));
     }
 
-    append_callback(url);
-
+    // add url to the results for the jobHandle
+    add_url_callback(url, jobHandle);
+ 
     Vix_FreeBuffer(url);
 }
 

--- a/helper.c
+++ b/helper.c
@@ -132,8 +132,7 @@ VixError get_file_info(VixHandle jobHandle,
 void find_items_callback(
     VixHandle jobHandle,
     VixEventType eventType,
-    VixHandle moreEventInfo,
-    void* goCallback) {
+    VixHandle moreEventInfo) {
 
     VixError err = VIX_OK;
     char* url = NULL;
@@ -154,10 +153,9 @@ void find_items_callback(
         printf("Error %s\n", Vix_GetErrorText(err, NULL));
     }
 
-    go_callback_char(goCallback, url);
-    free(goCallback);
-    Vix_FreeBuffer(url);
+    append_callback(url);
 
+    Vix_FreeBuffer(url);
 }
 
 VixError get_guest_file(VixHandle jobHandle, int i, char* name, int64* size, int64* modtime, int* flags) {

--- a/helper.h
+++ b/helper.h
@@ -59,8 +59,7 @@ VixError get_guest_process(VixHandle jobHandle,
 void find_items_callback(
 	VixHandle jobHandle,
 	VixEventType eventType,
-	VixHandle moreEventInfo,
-	void* goCallback);
+	VixHandle moreEventInfo);
 
 VixError get_num_shared_folders(VixHandle jobHandle, int* numSharedFolders);
 VixError read_variable(VixHandle jobHandle, char** readValue);


### PR DESCRIPTION
Hi there,

Passing Go Pointers that point to Go Memory into C, is illegal since go 1.6
The FindItems function receives a pointer to a go callback function.

This leads to a panic when calling the host.FindItems function:
panic: runtime error: cgo argument has Go pointer to Go pointer
 
I did a little refactoring to make it work again: sending the result items back now happens by using the exported append_callback, instead of using a generic callback function

Also the examples were fixed and can now be compiled, and the readme was updated with some Installation tips.

Edit: If accepting this pull request, the import statements in the examples should be changed back to: "github.com/hooklift/govix"

cheers